### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/src/db/crud/beer_cap_crud.py
+++ b/src/db/crud/beer_cap_crud.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/services/beer_cap_facade.py
+++ b/src/services/beer_cap_facade.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, BinaryIO, Callable, Optional
+from typing import BinaryIO, Callable, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 


### PR DESCRIPTION
## Summary
- remove unused typing imports from beer cap CRUD and facade modules

## Testing
- `ruff check --select F401 src tests`
- `pre-commit run --files src/db/crud/beer_cap_crud.py src/services/beer_cap_facade.py`
- `pytest` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a605558b4c83258b978876d97a4981